### PR TITLE
Add eigen as a build dependency.

### DIFF
--- a/realsense_ros2_camera/package.xml
+++ b/realsense_ros2_camera/package.xml
@@ -10,6 +10,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
   <build_depend>builtin_interfaces</build_depend>
+  <build_depend>eigen</build_depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>rmw_implementation</build_depend>
   <build_depend>std_msgs</build_depend>


### PR DESCRIPTION
Addresses the failure in http://build.ros2.org/view/Cdev/job/Cdev__ros2_intel_realsense__ubuntu_bionic_amd64/3