### PR TITLE
Adapt to ROS2 Dashing: automatically declare paramter

### DIFF
--- a/realsense_ros2_camera/src/realsense_camera_node.cpp
+++ b/realsense_ros2_camera/src/realsense_camera_node.cpp
@@ -98,7 +98,8 @@ class RealSenseCameraNode : public rclcpp::Node
 {
 public:
   RealSenseCameraNode()
-  : Node("RealSenseCameraNode"),
+  : Node("RealSenseCameraNode",
+      rclcpp::NodeOptions().automatically_declare_parameters_from_overrides(true)),
     _ros_clock(RCL_ROS_TIME),
     _serial_no(""),
     _base_frame_id(""),

--- a/realsense_ros2_camera/src/realsense_camera_node.cpp
+++ b/realsense_ros2_camera/src/realsense_camera_node.cpp
@@ -1130,7 +1130,7 @@ private:
     unsigned char * color_data = _image[COLOR].data;
     sensor_msgs::msg::PointCloud2 msg_pointcloud;
     msg_pointcloud.header.stamp = t;
-    msg_pointcloud.header.frame_id = _optical_frame_id[DEPTH];
+    msg_pointcloud.header.frame_id = _optical_frame_id[COLOR];
     msg_pointcloud.width = depth_intrinsics.width;
     msg_pointcloud.height = depth_intrinsics.height;
     msg_pointcloud.is_dense = true;


### PR DESCRIPTION
Fix issue https://github.com/intel/ros2_intel_realsense/issues/55

According to discussion in RCLCPP, for ROS2 Dashing release,
"declare parameter" is expected to load configures from yaml file.

See detail discussion here:
https://github.com/ros2/rclcpp/issues/715

Signed-off-by: Sharron LIU <sharron.liu@intel.com>