### PR TITLE
Fix dependencies in realsense_ros2_camera

### DIFF
--- a/realsense_ros2_camera/CMakeLists.txt
+++ b/realsense_ros2_camera/CMakeLists.txt
@@ -49,11 +49,6 @@ if(UNIX OR APPLE)
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pie")
 endif()
 
-find_package(librealsense2)
-if(NOT librealsense2_FOUND)
-  message(FATAL_ERROR "\n\n Intel RealSense SDK 2.0 is missing, please install it from https://github.com/IntelRealSense/librealsense/releases\n\n")
-endif()
-
 if(CMAKE_BUILD_TYPE EQUAL "RELEASE")
   message(STATUS "Create Release Build.")
   set(CMAKE_CXX_FLAGS "-O2 ${CMAKE_CXX_FLAGS}")
@@ -64,29 +59,19 @@ endif()
 set(CMAKE_CXX_FLAGS "-fPIE -fPIC -D_FORTIFY_SOURCE=2 -fstack-protector -Wformat -Wformat-security -Wall ${CMAKE_CXX_FLAGS}")
 
 find_package(ament_cmake REQUIRED)
-find_package(rosidl_default_generators REQUIRED)
 find_package(builtin_interfaces REQUIRED)
+find_package(cv_bridge REQUIRED)
+find_package(image_transport REQUIRED)
+find_package(librealsense2 REQUIRED)
 find_package(rclcpp REQUIRED)
-find_package(rmw_implementation REQUIRED)
+find_package(realsense_camera_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(tf2 REQUIRED)
-find_package(realsense_camera_msgs REQUIRED)
-find_package(cv_bridge REQUIRED)
-find_package(OpenCV REQUIRED)
-find_package(image_transport REQUIRED)
 
 include_directories(
   include
-  ${rclcpp_INCLUDE_DIRS}
-  ${rmw_implementation_INCLUDE_DIRS}
-  ${std_msgs_INCLUDE_DIRS}
-  ${sensor_msgs_INCLUDE_DIRS}
-  ${cv_bridge_INCLUDE_DIRS}
-  ${tf2_ros_INCLUDE_DIRS}
-  ${tf2_INCLUDE_DIRS}
-  ${librealsense2_INCLUDE_DIRS}
 )
 
 add_executable(${PROJECT_NAME}
@@ -94,29 +79,16 @@ add_executable(${PROJECT_NAME}
   src/realsense_camera_node.cpp
 )
 
-target_link_libraries(${PROJECT_NAME}
-  ${rclcpp_LIBRARIES}
-  ${rmw_implementation_LIBRARIES}
-  ${std_msgs_LIBRARIES}
-  ${sensor_msgs_LIBRARIES}
-  ${tf2_ros_LIBRARIES}
-  ${tf2_LIBRARIES}
-  ${realsense_camera_msgs_LIBRARIES}
-  ${cv_bridge_LIBRARIES}
-  ${librealsense2_LIBRARIES}
-)
 ament_target_dependencies(${PROJECT_NAME}
-  rclcpp
-  rmw_implementation
-  std_msgs
-  sensor_msgs
-  tf2_ros
-  tf2
-  realsense_camera_msgs
   cv_bridge
-  OpenCV
   image_transport
   librealsense2
+  rclcpp
+  realsense_camera_msgs
+  std_msgs
+  sensor_msgs
+  tf2
+  tf2_ros
 )
 
 # Install binaries
@@ -142,6 +114,8 @@ install(DIRECTORY
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
+  find_package(OpenCV REQUIRED)
+
   ament_lint_auto_find_test_dependencies()
 
   set(REALSENSE_DEVICE_PLUGIN FALSE)
@@ -152,12 +126,12 @@ if(BUILD_TESTING)
     target_include_directories(test_api PUBLIC
       ${${PROJECT_NAME}_INCLUDE_DIRS}
     )
-    ament_target_dependencies(test_api
-      rclcpp
-      sensor_msgs
-      tf2_ros
-      tf2
-      OpenCV)
+  ament_target_dependencies(test_api
+    OpenCV
+    rclcpp
+    sensor_msgs
+    tf2
+    tf2_ros)
   endif()
 endif()
 

--- a/realsense_ros2_camera/launch/realsense2_to_laserscan.py
+++ b/realsense_ros2_camera/launch/realsense2_to_laserscan.py
@@ -14,26 +14,25 @@
 
 """Launch face detection and rviz."""
 
-import os
-from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-import launch_ros.actions
 import launch.actions
+import launch_ros.actions
 
 
 def generate_launch_description():
-    enable_align_depth = launch.substitutions.LaunchConfiguration('enable_aligned_depth', default="false")
-    output_frame = launch.substitutions.LaunchConfiguration('output_frame', default="base_scan")
-    range_max = launch.substitutions.LaunchConfiguration('range_max', default="2.0")
-    range_min = launch.substitutions.LaunchConfiguration('range_min', default="0.2")
+    enable_align_depth = launch.substitutions.LaunchConfiguration('enable_aligned_depth',
+                                                                  default='false')
+    output_frame = launch.substitutions.LaunchConfiguration('output_frame', default='base_scan')
+    range_max = launch.substitutions.LaunchConfiguration('range_max', default='2.0')
+    range_min = launch.substitutions.LaunchConfiguration('range_min', default='0.2')
     return LaunchDescription([
         # Realsense
         launch_ros.actions.Node(
             package='realsense_ros2_camera',
             node_executable='realsense_ros2_camera',
             node_name='realsense_ros2_camera',
-            parameters=[{'enable_aligned_depth':enable_align_depth}],
-            output='screen'), 
+            parameters=[{'enable_aligned_depth': enable_align_depth}],
+            output='screen'),
         launch_ros.actions.Node(
             package='depthimage_to_laserscan',
             node_executable='depthimage_to_laserscan_node',
@@ -42,7 +41,7 @@ def generate_launch_description():
             parameters=[{'output_frame': output_frame},
                         {'range_min': range_min},
                         {'range_max': range_max}],
-            arguments=["depth:=/camera/depth/image_rect_raw",
-                       "depth_camera_info:=/camera/depth/camera_info",
-                       "scan:=/scan"]),
+            arguments=['depth:=/camera/depth/image_rect_raw',
+                       'depth_camera_info:=/camera/depth/camera_info',
+                       'scan:=/scan']),
     ])

--- a/realsense_ros2_camera/launch/rs.launch.py
+++ b/realsense_ros2_camera/launch/rs.launch.py
@@ -14,16 +14,11 @@
 
 """Launch realsense_ros2_camera node without rviz2."""
 
-import os
-
-from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 import launch_ros.actions
 
 
 def generate_launch_description():
-    default_rviz = os.path.join(get_package_share_directory('realsense_ros2_camera'),
-                                'launch', 'default.rviz')
     return LaunchDescription([
         # Realsense
         launch_ros.actions.Node(

--- a/realsense_ros2_camera/package.xml
+++ b/realsense_ros2_camera/package.xml
@@ -9,33 +9,24 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <buildtool_depend>rosidl_default_generators</buildtool_depend>
-  <build_depend>builtin_interfaces</build_depend>
-  <build_depend>eigen</build_depend>
-  <build_depend>rclcpp</build_depend>
-  <build_depend>rmw_implementation</build_depend>
-  <build_depend>std_msgs</build_depend>
-  <build_depend>sensor_msgs</build_depend>
-  <build_depend>tf2_ros</build_depend>
-  <build_depend>realsense_camera_msgs</build_depend>
-  <build_depend>cv_bridge</build_depend>
-  <build_depend>image_transport</build_depend>
-  <build_depend>librealsense2</build_depend>
 
-  <exec_depend>rosidl_default_runtime</exec_depend>
-  <exec_depend>builtin_interfaces</exec_depend>
-  <exec_depend>rclcpp</exec_depend>
-  <exec_depend>rmw_implementation</exec_depend>
-  <exec_depend>std_msgs</exec_depend>
-  <exec_depend>sensor_msgs</exec_depend>
-  <exec_depend>tf2_ros</exec_depend>
-  <exec_depend>realsense_camera_msgs</exec_depend>
-  <exec_depend>cv_bridge</exec_depend>
-  <exec_depend>librealsense2</exec_depend>
+  <build_depend>eigen</build_depend>
+
+  <depend>builtin_interfaces</depend>
+  <depend>cv_bridge</depend>
+  <depend>image_transport</depend>
+  <depend>librealsense2</depend>
+  <depend>rclcpp</depend>
+  <depend>realsense_camera_msgs</depend>
+  <depend>sensor_msgs</depend>
+  <depend>std_msgs</depend>
+  <depend>tf2</depend>
+  <depend>tf2_ros</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>libopencv-dev</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/realsense_ros2_camera/src/realsense_camera_node.cpp
+++ b/realsense_ros2_camera/src/realsense_camera_node.cpp
@@ -38,6 +38,7 @@
 #include <algorithm>
 #include <csignal>
 #include <iostream>
+#include <limits>
 #include <map>
 #include <memory>
 #include <string>
@@ -68,7 +69,7 @@ const stream_index_pair GYRO{RS2_STREAM_GYRO, 0};
 const stream_index_pair ACCEL{RS2_STREAM_ACCEL, 0};
 
 const std::vector<std::vector<stream_index_pair>> IMAGE_STREAMS = {{{DEPTH, INFRA1, INFRA2},
-    {COLOR}, {FISHEYE}}};
+  {COLOR}, {FISHEYE}}};
 
 const std::vector<std::vector<stream_index_pair>> HID_STREAMS = {{GYRO, ACCEL}};
 
@@ -77,7 +78,7 @@ inline void signalHandler(int signum)
 {
   std::cout << strsignal(signum) << " Signal is received! Terminate RealSense Node...\n";
   auto sens = _dev.query_sensors();
-  for (auto it=sens.begin(); it!=sens.end(); it++) {
+  for (auto it = sens.begin(); it != sens.end(); it++) {
     it->stop();
     it->close();
   }
@@ -387,8 +388,7 @@ private:
       if (_align_pointcloud && _align_depth) {
         _align_pointcloud_publisher = this->create_publisher<sensor_msgs::msg::PointCloud2>(
           "camera/aligned_depth_to_color/color/points", 1);
-	  }
-
+      }
     }
 
     if (true == _enable[INFRA1]) {
@@ -545,7 +545,9 @@ private:
               publishPCTopic(t);
             }
 
-            if (_align_depth && _align_pointcloud && is_depth_frame_arrived && is_color_frame_arrived) {
+            if (_align_depth && _align_pointcloud && is_depth_frame_arrived &&
+              is_color_frame_arrived)
+            {
               RCLCPP_DEBUG(logger_, "publishAlignedPCTopic(...)");
               publishAlignedPCTopic(t);
             }
@@ -815,7 +817,7 @@ private:
     b2d_msg.transform.rotation.y = 0;
     b2d_msg.transform.rotation.z = 0;
     b2d_msg.transform.rotation.w = 1;
-   _static_tf_broadcaster_->sendTransform(b2d_msg);
+    _static_tf_broadcaster_->sendTransform(b2d_msg);
 
     // Transform depth frame to depth optical frame
     q_d2do.setRPY(-M_PI / 2, 0.0, -M_PI / 2);
@@ -829,7 +831,7 @@ private:
     d2do_msg.transform.rotation.y = q_d2do.getY();
     d2do_msg.transform.rotation.z = q_d2do.getZ();
     d2do_msg.transform.rotation.w = q_d2do.getW();
-   _static_tf_broadcaster_->sendTransform(d2do_msg);
+    _static_tf_broadcaster_->sendTransform(d2do_msg);
 
 
     if (true == _enable[COLOR]) {
@@ -846,7 +848,7 @@ private:
       b2c_msg.transform.rotation.y = q.y();
       b2c_msg.transform.rotation.z = q.z();
       b2c_msg.transform.rotation.w = q.w();
-     _static_tf_broadcaster_->sendTransform(b2c_msg);
+      _static_tf_broadcaster_->sendTransform(b2c_msg);
 
       // Transform color frame to color optical frame
       q_c2co.setRPY(-M_PI / 2, 0.0, -M_PI / 2);
@@ -860,7 +862,7 @@ private:
       c2co_msg.transform.rotation.y = q_c2co.getY();
       c2co_msg.transform.rotation.z = q_c2co.getZ();
       c2co_msg.transform.rotation.w = q_c2co.getW();
-     _static_tf_broadcaster_->sendTransform(c2co_msg);
+      _static_tf_broadcaster_->sendTransform(c2co_msg);
     }
 
     if (_enable[DEPTH]) {
@@ -886,7 +888,7 @@ private:
         b2ir1_msg.transform.rotation.y = q.y();
         b2ir1_msg.transform.rotation.z = q.z();
         b2ir1_msg.transform.rotation.w = q.w();
-       _static_tf_broadcaster_->sendTransform(b2ir1_msg);
+        _static_tf_broadcaster_->sendTransform(b2ir1_msg);
 
         // Transform infra1 frame to infra1 optical frame
         ir1_2_ir1o.setRPY(-M_PI / 2, 0.0, -M_PI / 2);
@@ -900,7 +902,7 @@ private:
         ir1_2_ir1o_msg.transform.rotation.y = ir1_2_ir1o.getY();
         ir1_2_ir1o_msg.transform.rotation.z = ir1_2_ir1o.getZ();
         ir1_2_ir1o_msg.transform.rotation.w = ir1_2_ir1o.getW();
-       _static_tf_broadcaster_->sendTransform(ir1_2_ir1o_msg);
+        _static_tf_broadcaster_->sendTransform(ir1_2_ir1o_msg);
       }
 
       if (true == _enable[INFRA2]) {
@@ -918,7 +920,7 @@ private:
         b2ir2_msg.transform.rotation.y = q.y();
         b2ir2_msg.transform.rotation.z = q.z();
         b2ir2_msg.transform.rotation.w = q.w();
-       _static_tf_broadcaster_->sendTransform(b2ir2_msg);
+        _static_tf_broadcaster_->sendTransform(b2ir2_msg);
 
         // Transform infra2 frame to infra1 optical frame
         ir2_2_ir2o.setRPY(-M_PI / 2, 0.0, -M_PI / 2);
@@ -932,7 +934,7 @@ private:
         ir2_2_ir2o_msg.transform.rotation.y = ir2_2_ir2o.getY();
         ir2_2_ir2o_msg.transform.rotation.z = ir2_2_ir2o.getZ();
         ir2_2_ir2o_msg.transform.rotation.w = ir2_2_ir2o.getW();
-       _static_tf_broadcaster_->sendTransform(ir2_2_ir2o_msg);
+        _static_tf_broadcaster_->sendTransform(ir2_2_ir2o_msg);
       }
     }
     // Publish Fisheye TF
@@ -1013,7 +1015,6 @@ private:
 
   void publishAlignedDepthImg(rs2::frame depth_frame, const rclcpp::Time & t)
   {
-
     rs2::align align(RS2_STREAM_COLOR);
     _aligned_frameset = depth_frame.apply_filter(align);
     rs2::depth_frame aligned_depth = _aligned_frameset.get_depth_frame();
@@ -1021,7 +1022,7 @@ private:
 
     auto vf = aligned_depth.as<rs2::video_frame>();
     auto depth_image = cv::Mat(cv::Size(vf.get_width(), vf.get_height()), _image_format[DEPTH],
-			(void*)vf.get_data(), cv::Mat::AUTO_STEP);
+        const_cast<void *>(vf.get_data()), cv::Mat::AUTO_STEP);
 
     sensor_msgs::msg::Image::SharedPtr img;
     auto info_msg = _camera_info[DEPTH];
@@ -1039,7 +1040,6 @@ private:
     img->header.stamp = t;
     _align_depth_publisher.publish(img);
     _align_depth_camera_publisher->publish(info_msg);
-
   }
 
   void publishPCTopic(const rclcpp::Time & t)
@@ -1161,23 +1161,23 @@ private:
         scaled_depth = static_cast<float>(*image_depth16) * _depth_scale_meters;
         float depth_pixel[2] = {static_cast<float>(x), static_cast<float>(y)};
         rs2_deproject_pixel_to_point(depth_point, &depth_intrinsics, depth_pixel, scaled_depth);
-        auto iter_offset = x  + y * depth_intrinsics.width;
+        auto iter_offset = x + y * depth_intrinsics.width;
 
         if (depth_point[2] <= 0.f || depth_point[2] > 5.f) {
-            *(iter_x + iter_offset) = std_nan;
-            *(iter_y + iter_offset) = std_nan;
-            *(iter_z + iter_offset) = std_nan;
-            *(iter_r + iter_offset) = static_cast<uint8_t>(96);
-            *(iter_g + iter_offset) = static_cast<uint8_t>(157);
-            *(iter_b + iter_offset) = static_cast<uint8_t>(198);
+          *(iter_x + iter_offset) = std_nan;
+          *(iter_y + iter_offset) = std_nan;
+          *(iter_z + iter_offset) = std_nan;
+          *(iter_r + iter_offset) = static_cast<uint8_t>(96);
+          *(iter_g + iter_offset) = static_cast<uint8_t>(157);
+          *(iter_b + iter_offset) = static_cast<uint8_t>(198);
         } else {
-            *(iter_x + iter_offset) = depth_point[0];
-            *(iter_y + iter_offset) = depth_point[1];
-            *(iter_z + iter_offset) = depth_point[2];
-            *(iter_r + iter_offset) = color_data[iter_offset*3];
-            *(iter_g + iter_offset) = color_data[iter_offset*3 + 1];
-            *(iter_b + iter_offset) = color_data[iter_offset*3 + 2];
-		}
+          *(iter_x + iter_offset) = depth_point[0];
+          *(iter_y + iter_offset) = depth_point[1];
+          *(iter_z + iter_offset) = depth_point[2];
+          *(iter_r + iter_offset) = color_data[iter_offset * 3];
+          *(iter_g + iter_offset) = color_data[iter_offset * 3 + 1];
+          *(iter_b + iter_offset) = color_data[iter_offset * 3 + 2];
+        }
 
         ++image_depth16;
       }


### PR DESCRIPTION
I recently tried to run:

```
sudo apt-get install ros-dashing-realsense-ros2-camera
```

After doing that and then trying to run the camera with:
```
ros2 run realsense_ros2_camera realsense_ros2_camera
```

I get an error message:
```
/opt/ros/dashing/lib/realsense_ros2_camera/realsense_ros2_camera: error while loading shared libraries: libimage_transport.so: cannot open shared object file: No such file or directory
```

This is because the package.xml has a build dependency on image_transport, but forgets the exec dependency.  While I was in here, I did a bit of cleanup to remove unnecessary dependencies and make the tests pass.  This will likely conflict with some of the other open PRs, but I think this should probably go in first (and be released); otherwise, anyone trying to install the dashing packages will not have a good out-of-box experience.