### PR TITLE
provide two modes for the pointcloud topic

### DIFF
--- a/realsense_ros/config/d415.yaml
+++ b/realsense_ros/config/d415.yaml
@@ -3,6 +3,7 @@ camera:
     serial_no: 725112060212 # d415
     align_depth: false
     enable_pointcloud: false
+    dense_pointcloud: true
     #base_frame_id:
     color0:
       enabled: true

--- a/realsense_ros/config/d435.yaml
+++ b/realsense_ros/config/d435.yaml
@@ -3,6 +3,7 @@ camera:
     serial_no: 727212071015 # d435
     align_depth: false
     enable_pointcloud: false
+    dense_pointcloud: true
     #base_frame_id:
     color0:
       enabled: true

--- a/realsense_ros/config/d435i.yaml
+++ b/realsense_ros/config/d435i.yaml
@@ -2,7 +2,8 @@ camera:
   ros__parameters:
     serial_no: 843112073259 # d435i
     align_depth: false
-    enable_pointcloud: false
+    enable_pointcloud: true
+    dense_pointcloud: true
     #base_frame_id:
     color0:
       enabled: true

--- a/realsense_ros/config/multi_cams.yaml
+++ b/realsense_ros/config/multi_cams.yaml
@@ -4,6 +4,7 @@
       serial_no: 727212071015 #d435
       align_depth: true
       enable_pointcloud: true
+      dense_pointcloud: true
       #base_frame_id:
       color0:
         enabled: true

--- a/realsense_ros/include/realsense/rs_constants.hpp
+++ b/realsense_ros/include/realsense/rs_constants.hpp
@@ -38,6 +38,7 @@ namespace realsense
 
   const bool ALIGN_DEPTH = false;
   const bool ENABLE_POINTCLOUD = false;
+  const bool DENSE_PC = true;
   const bool DEFAULT_ENABLE_STREAM = true;
 
   const std::vector<int> DEFAULT_IMAGE_RESOLUTION = {640, 480};

--- a/realsense_ros/include/realsense/rs_d435.hpp
+++ b/realsense_ros/include/realsense/rs_d435.hpp
@@ -35,12 +35,14 @@ public:
   virtual void publishTopicsCallback(const rs2::frame & frame) override;
   virtual Result paramChangeCallback(const std::vector<rclcpp::Parameter> & params) override;
   void publishAlignedDepthTopic(const rs2::frame & frame, const rclcpp::Time & time);
-  void publishPointCloud(const rs2::points & points, const rs2::video_frame & color_frame, const rclcpp::Time & time);
+  void publishSparsePointCloud(const rs2::points & points, const rs2::video_frame & color_frame, const rclcpp::Time & time);
+  void publishDensePointCloud(const rs2::points & points, const rs2::video_frame & color_frame, const rclcpp::Time & time);
   void updateStreamCalibData(const rs2::video_stream_profile & video_profile);
 
 protected:
   bool align_depth_;
   bool enable_pointcloud_;
+  bool dense_pc_;
   bool initialized_ = false;
   rs2::align align_to_color_ = rs2::align(RS2_STREAM_COLOR);
   rs2::pointcloud pc_;


### PR DESCRIPTION
1. sparse mode: only publish valid points, but without structrual
information, e.g. width and height
2. dense mode: publish all points including invalid ones with width and
height information.

Signed-off-by: Xiaojun <xiaojun.huang@intel.com>