### PR TITLE
Add Dockerfile for reproducible builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,57 @@
+ARG FROM_IMAGE=ruffsl/librealsense:development
+
+# multi-stage for caching
+FROM $FROM_IMAGE AS cache
+
+# copy overlay source
+ENV REALSENSE_WS /opt/realsense_ws
+RUN mkdir -p $REALSENSE_WS/src
+WORKDIR $REALSENSE_WS
+COPY ./ src/ros2_intel_realsense
+
+# copy manifests for caching
+WORKDIR /opt
+RUN find ./ -name "package.xml" | \
+      xargs cp --parents -t /tmp
+    # && find ./ -name "COLCON_IGNORE" | \
+    #   xargs cp --parents -t /tmp
+
+# multi-stage for building
+FROM $FROM_IMAGE AS build
+
+# install CI dependencies
+RUN apt-get update && apt-get install -q -y \
+      ccache \
+      lcov \
+    && rm -rf /var/lib/apt/lists/*
+
+# copy overlay manifests
+ENV REALSENSE_WS /opt/realsense_ws
+COPY --from=cache /tmp/realsense_ws $REALSENSE_WS
+WORKDIR $REALSENSE_WS
+
+# install overlay dependencies
+RUN . $OVERLAY_WS/install/setup.sh && \
+    apt-get update && rosdep install -q -y \
+      --from-paths \
+        src \
+        $OVERLAY_WS/src \
+      --ignore-src \
+    && rm -rf /var/lib/apt/lists/*
+
+# copy overlay source
+COPY --from=cache $REALSENSE_WS ./
+
+# build overlay source
+ARG REALSENSE_MIXINS="release ccache"
+RUN . $OVERLAY_WS/install/setup.sh && \
+    colcon build \
+      --symlink-install \
+      --mixin \
+        $REALSENSE_MIXINS \
+      --event-handlers console_direct+
+
+# source overlay from entrypoint
+RUN sed --in-place \
+      's|^source .*|source "$REALSENSE_WS/install/setup.bash"|' \
+      /ros_entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,9 @@ RUN vcs import src < underlay.repos
 ENV OVERLAY_WS /opt/overlay_ws
 RUN mkdir -p $OVERLAY_WS/src
 WORKDIR $OVERLAY_WS
-# COPY ./ src/navigation2
-COPY ./tools/overlay.repos ./
-RUN vcs import src < overlay.repos
+COPY ./ src/navigation2
+# COPY ./tools/overlay.repos ./
+# RUN vcs import src < overlay.repos
 
 # copy manifests for caching
 WORKDIR /opt

--- a/realsense_examples/package.xml
+++ b/realsense_examples/package.xml
@@ -14,7 +14,7 @@
 
   <depend>realsense_ros</depend>
   <depend>realsense_node</depend>
-  <depend>realsense2</depend>
+  <depend>librealsense2</depend>
   <depend>realsense_msgs</depend>
 
   <exec_depend>launch_ros</exec_depend>

--- a/realsense_node/CMakeLists.txt
+++ b/realsense_node/CMakeLists.txt
@@ -73,6 +73,11 @@ find_package(tf2 REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(realsense_ros REQUIRED)
 find_package(realsense_msgs REQUIRED)
+find_package(realsense2 REQUIRED)
+
+include_directories(
+  ${realsense2_INCLUDE_DIR}
+)
 
 add_executable(realsense_node
   src/realsense_node.cpp

--- a/realsense_ros/CMakeLists.txt
+++ b/realsense_ros/CMakeLists.txt
@@ -96,7 +96,7 @@ add_library(${PROJECT_NAME} SHARED
 )
 
 target_link_libraries(${PROJECT_NAME}
-  realsense2
+  ${realsense2_LIBRARY}
 )
 
 ament_target_dependencies(${PROJECT_NAME}
@@ -108,7 +108,7 @@ ament_target_dependencies(${PROJECT_NAME}
   tf2
   tf2_ros
   pcl_conversions
-  realsense2
+  librealsense2
   realsense_msgs
 )
 
@@ -159,7 +159,7 @@ if(BUILD_TESTING)
         ${${PROJECT_NAME}_INCLUDE_DIRS}
       )
       target_link_libraries(${target}
-        realsense2
+        ${realsense2_LIBRARY}
 	${PROJECT_NAME})
       ament_target_dependencies(${target}
         "rclcpp"

--- a/realsense_ros/CMakeLists.txt
+++ b/realsense_ros/CMakeLists.txt
@@ -82,7 +82,7 @@ endif()
 
 include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}/include
-  ${realsense2_INCLUDE_DIRS}
+  ${realsense2_INCLUDE_DIR}
 )
 
 set(node_plugins "")

--- a/realsense_ros/CMakeLists.txt
+++ b/realsense_ros/CMakeLists.txt
@@ -108,7 +108,7 @@ ament_target_dependencies(${PROJECT_NAME}
   tf2
   tf2_ros
   pcl_conversions
-  librealsense2
+  realsense2
   realsense_msgs
 )
 

--- a/realsense_ros/package.xml
+++ b/realsense_ros/package.xml
@@ -17,7 +17,7 @@
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
   <depend>pcl_conversions</depend>
-  <depend>realsense2</depend>
+  <depend>librealsense2</depend>
   <depend>realsense_msgs</depend>
   <depend>image_transport</depend>
 

--- a/tools/overlay.repos
+++ b/tools/overlay.repos
@@ -1,0 +1,5 @@
+repositories:
+  ros2_intel_realsense:
+    type: git
+    url: https://github.com/intel/ros2_intel_realsense.git
+    version: master

--- a/tools/overlay.repos
+++ b/tools/overlay.repos
@@ -1,5 +1,5 @@
 repositories:
   ros2_intel_realsense:
     type: git
-    url: https://github.com/intel/ros2_intel_realsense.git
-    version: master
+    url: https://github.com/ruffsl/ros2_intel_realsense.git
+    version: docker

--- a/tools/underlay.repos
+++ b/tools/underlay.repos
@@ -1,0 +1,5 @@
+repositories:
+  librealsense:
+    type: git
+    url: https://github.com/ruffsl/librealsense.git
+    version: package-fix


### PR DESCRIPTION
I wanted to compile the latest version of the refactor branch to test realsense on ROS2 Eloquent, but encountered a number of small small cmake issues that I suspect went unnoticed given that the build process may not have been recently tested using a clean environment such as a fresh Docker image. Perhaps we upstream this Dockerfile and changes to help maintain health of the build?

Related: https://github.com/IntelRealSense/librealsense/pull/5286 