### PR TITLE
Enable linear interpolate of Gyro and Accel data over IMU topic

### DIFF
--- a/realsense_ros/CMakeLists.txt
+++ b/realsense_ros/CMakeLists.txt
@@ -100,8 +100,11 @@ target_link_libraries(${PROJECT_NAME}
   realsense2
 )
 
+target_include_directories(${PROJECT_NAME} PRIVATE
+  ${rcl_INCLUDE_DIRS}
+)
+
 ament_target_dependencies(${PROJECT_NAME}
-  rcl
   rclcpp
   rclcpp_components
   nav_msgs
@@ -164,8 +167,9 @@ if(BUILD_TESTING)
       target_link_libraries(${target}
         realsense2
 	${PROJECT_NAME})
+      target_include_directories(${PROJECT_NAME} PRIVATE
+        ${rcl_INCLUDE_DIRS})
       ament_target_dependencies(${target}
-        "rcl"
         "rclcpp"
         "nav_msgs"
         "sensor_msgs"

--- a/realsense_ros/CMakeLists.txt
+++ b/realsense_ros/CMakeLists.txt
@@ -100,11 +100,8 @@ target_link_libraries(${PROJECT_NAME}
   realsense2
 )
 
-target_include_directories(${PROJECT_NAME} PRIVATE
-  ${rcl_INCLUDE_DIRS}
-)
-
 ament_target_dependencies(${PROJECT_NAME}
+  rcl
   rclcpp
   rclcpp_components
   nav_msgs
@@ -167,9 +164,8 @@ if(BUILD_TESTING)
       target_link_libraries(${target}
         realsense2
 	${PROJECT_NAME})
-      target_include_directories(${PROJECT_NAME} PRIVATE
-        ${rcl_INCLUDE_DIRS})
       ament_target_dependencies(${target}
+        "rcl"
         "rclcpp"
         "nav_msgs"
         "sensor_msgs"

--- a/realsense_ros/CMakeLists.txt
+++ b/realsense_ros/CMakeLists.txt
@@ -65,6 +65,7 @@ set(CMAKE_CXX_FLAGS "-fPIE -fPIC -D_FORTIFY_SOURCE=2 -fstack-protector -Wformat 
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
+find_package(rcl REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(nav_msgs REQUIRED)
@@ -100,6 +101,7 @@ target_link_libraries(${PROJECT_NAME}
 )
 
 ament_target_dependencies(${PROJECT_NAME}
+  rcl
   rclcpp
   rclcpp_components
   nav_msgs
@@ -133,6 +135,7 @@ install(
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
+  find_package(rcl REQUIRED)
   find_package(rclcpp REQUIRED)
   find_package(nav_msgs REQUIRED)
   find_package(sensor_msgs REQUIRED)
@@ -162,6 +165,7 @@ if(BUILD_TESTING)
         realsense2
 	${PROJECT_NAME})
       ament_target_dependencies(${target}
+        "rcl"
         "rclcpp"
         "nav_msgs"
         "sensor_msgs"

--- a/realsense_ros/include/realsense/rs_base.hpp
+++ b/realsense_ros/include/realsense/rs_base.hpp
@@ -15,6 +15,7 @@
 #ifndef REALSENSE__RS_BASE_HPP_
 #define REALSENSE__RS_BASE_HPP_
 
+#include "rcl/time.h"
 #include "rclcpp/rclcpp.hpp"
 #include "sensor_msgs/msg/image.hpp"
 #include "sensor_msgs/msg/camera_info.hpp"
@@ -80,6 +81,7 @@ protected:
   Result toggleStream(const stream_index_pair & stream, const rclcpp::Parameter & param);
   Result changeResolution(const stream_index_pair & stream, const rclcpp::Parameter & param);
   Result changeFPS(const stream_index_pair & stream, const rclcpp::Parameter & param);
+  rclcpp::Time frameToTime(const rs2::frame & frame);
 
   typedef struct VideoStreamInfo
   {

--- a/realsense_ros/include/realsense/rs_base.hpp
+++ b/realsense_ros/include/realsense/rs_base.hpp
@@ -108,7 +108,7 @@ protected:
   rclcpp::TimerBase::SharedPtr timer_;
   std::map<stream_index_pair, bool> enable_ = {{COLOR, false}, {DEPTH, false},
                                                {INFRA1, false}, {INFRA2, false},
-                                               {ACCEL, false}, {GYRO, false},
+                                               {ACCEL, false}, {GYRO, false}, {IMU, false},
                                                {FISHEYE1, false}, {FISHEYE2, false},
                                                {POSE, false}};
 

--- a/realsense_ros/include/realsense/rs_base.hpp
+++ b/realsense_ros/include/realsense/rs_base.hpp
@@ -15,7 +15,6 @@
 #ifndef REALSENSE__RS_BASE_HPP_
 #define REALSENSE__RS_BASE_HPP_
 
-#include "rcl/time.h"
 #include "rclcpp/rclcpp.hpp"
 #include "sensor_msgs/msg/image.hpp"
 #include "sensor_msgs/msg/camera_info.hpp"

--- a/realsense_ros/include/realsense/rs_base.hpp
+++ b/realsense_ros/include/realsense/rs_base.hpp
@@ -81,6 +81,7 @@ protected:
   Result changeResolution(const stream_index_pair & stream, const rclcpp::Parameter & param);
   Result changeFPS(const stream_index_pair & stream, const rclcpp::Parameter & param);
   rclcpp::Time frameToTime(const rs2::frame & frame);
+  rclcpp::Time msToTime(const double &ms);
 
   typedef struct VideoStreamInfo
   {

--- a/realsense_ros/include/realsense/rs_constants.hpp
+++ b/realsense_ros/include/realsense/rs_constants.hpp
@@ -72,7 +72,7 @@ namespace realsense
 
   const std::string DEFAULT_ALIGNED_DEPTH_TO_COLOR_FRAME_ID = "camera_aligned_depth_to_color_frame";
 
-  const std::string DEFAULT_UNITE_IMU_METHOD         = "";
+  const std::string DEFAULT_UNITE_IMU_METHOD         = "linear_interpolation";
   const std::string DEFAULT_FILTERS                  = "";
   const std::string DEFAULT_TOPIC_ODOM_IN            = "";
 

--- a/realsense_ros/include/realsense/rs_constants.hpp
+++ b/realsense_ros/include/realsense/rs_constants.hpp
@@ -32,8 +32,9 @@ namespace realsense
   const stream_index_pair INFRA2{RS2_STREAM_INFRARED, 2};
   const stream_index_pair FISHEYE1{RS2_STREAM_FISHEYE, 1};
   const stream_index_pair FISHEYE2{RS2_STREAM_FISHEYE, 2};
-  const stream_index_pair GYRO{RS2_STREAM_GYRO, 0};
   const stream_index_pair ACCEL{RS2_STREAM_ACCEL, 0};
+  const stream_index_pair GYRO{RS2_STREAM_GYRO, 0};
+  const stream_index_pair IMU{RS2_STREAM_ANY, 0};
   const stream_index_pair POSE{RS2_STREAM_POSE, 0};
 
   const bool ALIGN_DEPTH = true;
@@ -66,6 +67,7 @@ namespace realsense
   const std::string DEFAULT_FISHEYE2_OPTICAL_FRAME_ID = "camera_fisheye2_optical_frame";
   const std::string DEFAULT_ACCEL_OPTICAL_FRAME_ID    = "camera_accel_optical_frame";
   const std::string DEFAULT_GYRO_OPTICAL_FRAME_ID     = "camera_gyro_optical_frame";
+  const std::string DEFAULT_IMU_OPTICAL_FRAME_ID      = "camera_imu_optical_frame";
   const std::string DEFAULT_POSE_OPTICAL_FRAME_ID     = "camera_pose_optical_frame";
 
   const std::string DEFAULT_ALIGNED_DEPTH_TO_COLOR_FRAME_ID = "camera_aligned_depth_to_color_frame";
@@ -90,6 +92,7 @@ namespace realsense
                                                           {RS2_STREAM_FISHEYE, RS2_FORMAT_Y8},
                                                           {RS2_STREAM_ACCEL, RS2_FORMAT_MOTION_XYZ32F},
                                                           {RS2_STREAM_GYRO, RS2_FORMAT_MOTION_XYZ32F},
+                                                          {RS2_STREAM_ANY, RS2_FORMAT_MOTION_XYZ32F},
                                                           {RS2_STREAM_POSE, RS2_FORMAT_6DOF}};
 
   const std::map<rs2_stream, std::string> STREAM_NAME = {{RS2_STREAM_COLOR, "color"},
@@ -97,6 +100,7 @@ namespace realsense
                                                          {RS2_STREAM_INFRARED, "infra"},
                                                          {RS2_STREAM_ACCEL, "accel"},
                                                          {RS2_STREAM_GYRO, "gyro"},
+                                                         {RS2_STREAM_ANY, "imu"},
                                                          {RS2_STREAM_FISHEYE, "fisheye"},
                                                          {RS2_STREAM_POSE, "pose"}};
 
@@ -108,6 +112,7 @@ namespace realsense
                                                                      {FISHEYE2, DEFAULT_FISHEYE2_OPTICAL_FRAME_ID},
                                                                      {ACCEL, DEFAULT_ACCEL_OPTICAL_FRAME_ID},
                                                                      {GYRO, DEFAULT_GYRO_OPTICAL_FRAME_ID},
+                                                                     {IMU, DEFAULT_IMU_OPTICAL_FRAME_ID},
                                                                      {POSE, DEFAULT_POSE_OPTICAL_FRAME_ID}};
 
   const std::map<stream_index_pair, std::string> SAMPLE_TOPIC = {{COLOR, "camera/color/image_raw"},
@@ -118,6 +123,7 @@ namespace realsense
                                                                  {FISHEYE2, "camera/fisheye2/image_raw"},
                                                                  {ACCEL, "camera/accel/sample"},
                                                                  {GYRO, "camera/gyro/sample"},
+                                                                 {IMU, "camera/imu/sample"},
                                                                  {POSE, "camera/odom/sample"}};
 
   const std::map<stream_index_pair, std::string> INFO_TOPIC = {{COLOR, "camera/color/camera_info"},
@@ -128,6 +134,7 @@ namespace realsense
                                                                {FISHEYE2, "camera/fisheye2/camera_info"},
                                                                {ACCEL, "camera/accel/imu_info"},
                                                                {GYRO, "camera/gyro/imu_info"},
+                                                               {IMU, "camera/imu/imu_info"},
                                                                {POSE, ""}};
 
   const std::string ALIGNED_DEPTH_IMAGE_TOPIC = "camera/aligned_depth_to_color/image_raw";

--- a/realsense_ros/include/realsense/rs_d435i.hpp
+++ b/realsense_ros/include/realsense/rs_d435i.hpp
@@ -30,11 +30,11 @@ public:
   virtual ~RealSenseD435I() = default;
   virtual void publishTopicsCallback(const rs2::frame & frame) override;
   virtual Result paramChangeCallback(const std::vector<rclcpp::Parameter> & params) override;
-  void publishIMUTopic(const rs2::frame & frame, const rclcpp::Time & time);
+  void publishIMUTopic(const rs2::frame & frame);
   IMUInfo getIMUInfo(const rs2::frame & frame, const stream_index_pair & stream_index);
 
  public:
-  enum imu_sync_method{NONE, COPY, LINEAR_INTERPOLATION};
+  enum imu_sync_method{COPY, LINEAR_INTERPOLATION};
 
  protected:
   class float3
@@ -80,15 +80,16 @@ private:
 
   void FillImuData_Copy(const CimuData imu_data, std::deque<sensor_msgs::msg::Imu>& imu_msgs);
   void ImuMessage_AddDefaultValues(sensor_msgs::msg::Imu &imu_msg);
+  void imu_callback_sync(const rs2::frame & frame, imu_sync_method sync_method);
   void FillImuData_LinearInterpolation(const CimuData imu_data, std::deque<sensor_msgs::msg::Imu>& imu_msgs);
 
 private:
   const std::vector<stream_index_pair> IMAGE_STREAMS = {COLOR, DEPTH, INFRA1, INFRA2};
-  const std::vector<stream_index_pair> MOTION_STREAMS = {ACCEL, GYRO};
+  const std::vector<stream_index_pair> MOTION_STREAMS = {ACCEL, GYRO, IMU};
   double linear_accel_cov_;
   double angular_velocity_cov_;
   bool initialized_ = false;
-  imu_sync_method _imu_sync_method;
+  imu_sync_method imu_sync_method_;
 };
 }  // namespace perception
 #endif // REALSENSE__RS_D435I_HPP_

--- a/realsense_ros/include/realsense/rs_d435i.hpp
+++ b/realsense_ros/include/realsense/rs_d435i.hpp
@@ -17,6 +17,8 @@
 
 #include "realsense/rs_d435.hpp"
 
+#include <queue>
+
 using IMUInfo = realsense_msgs::msg::IMUInfo;
 
 namespace realsense
@@ -31,12 +33,62 @@ public:
   void publishIMUTopic(const rs2::frame & frame, const rclcpp::Time & time);
   IMUInfo getIMUInfo(const rs2::frame & frame, const stream_index_pair & stream_index);
 
+ public:
+  enum imu_sync_method{NONE, COPY, LINEAR_INTERPOLATION};
+
+ protected:
+  class float3
+  {
+   public:
+    float x, y, z;
+
+   public:
+    float3& operator*=(const float& factor)
+    {
+      x*=factor;
+      y*=factor;
+      z*=factor;
+      return (*this);
+    }
+    float3& operator+=(const float3& other)
+    {
+      x+=other.x;
+      y+=other.y;
+      z+=other.z;
+      return (*this);
+    }
+  };
+
+ private:
+  class CimuData
+  {
+   public:
+    CimuData() : m_time(-1) {};
+    CimuData(const stream_index_pair type, Eigen::Vector3d data, double time):
+        m_type(type),
+        m_data(data),
+        m_time(time){};
+    bool is_set() {return m_time > 0;};
+   public:
+    stream_index_pair m_type;
+    Eigen::Vector3d m_data;
+    double          m_time;
+  };
+
+private:
+  sensor_msgs::msg::Imu CreateUnitedMessage(const CimuData accel_data, const CimuData gyro_data);
+
+  void FillImuData_Copy(const CimuData imu_data, std::deque<sensor_msgs::msg::Imu>& imu_msgs);
+  void ImuMessage_AddDefaultValues(sensor_msgs::msg::Imu &imu_msg);
+  void FillImuData_LinearInterpolation(const CimuData imu_data, std::deque<sensor_msgs::msg::Imu>& imu_msgs);
+
 private:
   const std::vector<stream_index_pair> IMAGE_STREAMS = {COLOR, DEPTH, INFRA1, INFRA2};
   const std::vector<stream_index_pair> MOTION_STREAMS = {ACCEL, GYRO};
   double linear_accel_cov_;
   double angular_velocity_cov_;
   bool initialized_ = false;
+  imu_sync_method _imu_sync_method;
 };
 }  // namespace perception
 #endif // REALSENSE__RS_D435I_HPP_

--- a/realsense_ros/package.xml
+++ b/realsense_ros/package.xml
@@ -9,6 +9,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>rcl</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>nav_msgs</depend>

--- a/realsense_ros/package.xml
+++ b/realsense_ros/package.xml
@@ -9,7 +9,6 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <depend>rcl</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>nav_msgs</depend>
@@ -21,6 +20,8 @@
   <depend>realsense2</depend>
   <depend>realsense_msgs</depend>
   <depend>image_transport</depend>
+
+  <build_depend>rcl</build_depend>
 
   <exec_depend>launch_ros</exec_depend>
   

--- a/realsense_ros/src/rs_base.cpp
+++ b/realsense_ros/src/rs_base.cpp
@@ -95,14 +95,16 @@ void RealSenseBase::setupStream(const stream_index_pair & stream)
     enable = node_.declare_parameter(os.str(), DEFAULT_ENABLE_STREAM);
   }
 
-  if (stream == ACCEL || stream == GYRO) {
+  if (stream == ACCEL || stream == GYRO || stream == IMU) {
     imu_pub_.insert(std::pair<stream_index_pair, rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr>
       (stream, node_.create_publisher<sensor_msgs::msg::Imu>(SAMPLE_TOPIC.at(stream), rclcpp::QoS(1))));
     imu_info_pub_.insert(std::pair<stream_index_pair, rclcpp::Publisher<realsense_msgs::msg::IMUInfo>::SharedPtr>
       (stream, node_.create_publisher<realsense_msgs::msg::IMUInfo>(INFO_TOPIC.at(stream), rclcpp::QoS(1))));
     if (enable == true) {
       enable_[stream] = true;
-      cfg_.enable_stream(stream.first, stream.second);
+      if (stream != IMU) {
+        cfg_.enable_stream(stream.first, stream.second);
+      }
     }
   } else if (stream == POSE) {
     odom_pub_ = node_.create_publisher<nav_msgs::msg::Odometry>(SAMPLE_TOPIC.at(stream), rclcpp::QoS(1));

--- a/realsense_ros/src/rs_base.cpp
+++ b/realsense_ros/src/rs_base.cpp
@@ -457,4 +457,8 @@ Result RealSenseBase::changeFPS(const stream_index_pair & stream, const rclcpp::
   }
   return result;
 }
+
+rclcpp::Time RealSenseBase::frameToTime(const rs2::frame & frame) {
+  return rclcpp::Time(RCL_MS_TO_NS(frame.get_timestamp()));
+}
 }  // namespace realsense

--- a/realsense_ros/src/rs_base.cpp
+++ b/realsense_ros/src/rs_base.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <sstream>
+#include "rcl/time.h"
 #include "realsense/rs_base.hpp"
 
 namespace realsense

--- a/realsense_ros/src/rs_base.cpp
+++ b/realsense_ros/src/rs_base.cpp
@@ -462,4 +462,8 @@ Result RealSenseBase::changeFPS(const stream_index_pair & stream, const rclcpp::
 rclcpp::Time RealSenseBase::frameToTime(const rs2::frame & frame) {
   return rclcpp::Time(RCL_MS_TO_NS(frame.get_timestamp()));
 }
+
+rclcpp::Time RealSenseBase::msToTime(const double & ms) {
+  return rclcpp::Time(RCL_MS_TO_NS(ms));
+}
 }  // namespace realsense

--- a/realsense_ros/src/rs_d435.cpp
+++ b/realsense_ros/src/rs_d435.cpp
@@ -60,7 +60,7 @@ RealSenseD435::RealSenseD435(rs2::context ctx, rs2::device dev, rclcpp::Node & n
 void RealSenseD435::publishTopicsCallback(const rs2::frame & frame)
 {
   rs2::frameset frameset = frame.as<rs2::frameset>();
-  rclcpp::Time t = node_.now();
+  rclcpp::Time t = frameToTime(frame);
   if (enable_[COLOR] && (image_pub_[COLOR]->get_subscription_count() > 0 || camera_info_pub_[COLOR]->get_subscription_count() > 0)){
     auto frame = frameset.get_color_frame();
     publishImageTopic(frame, t);

--- a/realsense_ros/src/rs_d435i.cpp
+++ b/realsense_ros/src/rs_d435i.cpp
@@ -31,17 +31,34 @@ RealSenseD435I::RealSenseD435I(rs2::context ctx, rs2::device dev, rclcpp::Node &
   linear_accel_cov_ = DEFAULT_LINEAR_ACCEL_COV;
   angular_velocity_cov_ = DEFAULT_ANGULAR_VELOCITY_COV;
   initialized_ = true;
+
+  auto depth_sensor =  dev.first<rs2::depth_sensor>();
+  if (depth_sensor.supports(RS2_OPTION_EMITTER_ENABLED))
+  {
+//    depth_sensor.set_option(RS2_OPTION_EMITTER_ENABLED, 1.f); // Enable emitter
+    depth_sensor.set_option(RS2_OPTION_EMITTER_ENABLED, 0.f); // Disable emitter
+  }
+
+  std::string unite_imu_method_str("");
+  node_.get_parameter_or("unite_imu_method", unite_imu_method_str, DEFAULT_UNITE_IMU_METHOD);
+  if (unite_imu_method_str == "linear_interpolation")
+    imu_sync_method_ = imu_sync_method::LINEAR_INTERPOLATION;
+  else if (unite_imu_method_str == "copy")
+    imu_sync_method_ = imu_sync_method::COPY;
+  else {
+    RCLCPP_ERROR(node_.get_logger(), "Invalid value for unite_imu_method: %s", unite_imu_method_str.c_str());
+  }
 }
 
 void RealSenseD435I::publishTopicsCallback(const rs2::frame & frame)
 {
-  rclcpp::Time t = frameToTime(frame);
   if (frame.is<rs2::frameset>()) {
     RealSenseD435::publishTopicsCallback(frame);
   } else if (frame.is<rs2::motion_frame>()) {
     if ((enable_[ACCEL] && (imu_pub_[ACCEL]->get_subscription_count() > 0 || imu_info_pub_[ACCEL]->get_subscription_count() > 0))
-      || (enable_[GYRO] && (imu_pub_[GYRO]->get_subscription_count() > 0 || imu_info_pub_[GYRO]->get_subscription_count() > 0))) {
-      publishIMUTopic(frame, t);
+      || (enable_[GYRO] && (imu_pub_[GYRO]->get_subscription_count() > 0 || imu_info_pub_[GYRO]->get_subscription_count() > 0))
+      || (enable_[IMU] && (imu_pub_[IMU]->get_subscription_count() > 0 || imu_info_pub_[IMU]->get_subscription_count() > 0))) {
+      publishIMUTopic(frame);
     }
   }
 }
@@ -66,7 +83,7 @@ Result RealSenseD435I::paramChangeCallback(const std::vector<rclcpp::Parameter> 
   return result;
 }
 
-void RealSenseD435I::publishIMUTopic(const rs2::frame & frame, const rclcpp::Time & time)
+void RealSenseD435I::publishIMUTopic(const rs2::frame & frame)
 {
   auto type = frame.get_profile().stream_type();
   auto index = frame.get_profile().stream_index();
@@ -76,35 +93,32 @@ void RealSenseD435I::publishIMUTopic(const rs2::frame & frame, const rclcpp::Tim
   realsense_msgs::msg::IMUInfo info_msg;
 
   imu_msg.header.frame_id = OPTICAL_FRAME_ID.at(type_index);
-  imu_msg.orientation.x = 0.0;
-  imu_msg.orientation.y = 0.0;
-  imu_msg.orientation.z = 0.0;
-  imu_msg.orientation.w = 0.0;
-  imu_msg.orientation_covariance = {-1.0, 0.0, 0.0,
-                                     0.0, 0.0, 0.0,
-                                     0.0, 0.0, 0.0};
-  imu_msg.linear_acceleration_covariance = {linear_accel_cov_, 0.0, 0.0,
-                                            0.0, linear_accel_cov_, 0.0,
-                                            0.0, 0.0, linear_accel_cov_};
-  imu_msg.angular_velocity_covariance = {angular_velocity_cov_, 0.0, 0.0,
-                                         0.0, angular_velocity_cov_, 0.0,
-                                         0.0, 0.0, angular_velocity_cov_};
+  imu_msg.header.stamp = frameToTime(frame);
+  ImuMessage_AddDefaultValues(imu_msg);
 
   auto imu_data = m_frame.get_motion_data();
   if (type_index == GYRO) {
     imu_msg.angular_velocity.x = imu_data.x;
     imu_msg.angular_velocity.y = imu_data.y;
     imu_msg.angular_velocity.z = imu_data.z;
-    info_msg = getIMUInfo(frame, GYRO);
   } else if (type_index == ACCEL) {
     imu_msg.linear_acceleration.x = imu_data.x;
     imu_msg.linear_acceleration.y = imu_data.y;
     imu_msg.linear_acceleration.z = imu_data.z;
-    info_msg = getIMUInfo(frame, ACCEL);
   }
-  imu_msg.header.stamp = time;
-  imu_pub_[type_index]->publish(imu_msg);
-  imu_info_pub_[type_index]->publish(info_msg);
+
+  if (imu_pub_[type_index]->get_subscription_count() > 0){
+    imu_pub_[type_index]->publish(imu_msg);
+  }
+
+  if (imu_info_pub_[type_index]->get_subscription_count() > 0){
+    info_msg = getIMUInfo(frame, type_index);
+    imu_info_pub_[type_index]->publish(info_msg);
+  }
+
+  if (imu_pub_[IMU]->get_subscription_count() > 0 || imu_info_pub_[IMU]->get_subscription_count() > 0) {
+    imu_callback_sync(frame, imu_sync_method_);
+  }
 }
 
 IMUInfo RealSenseD435I::getIMUInfo(const rs2::frame & frame, const stream_index_pair & stream_index)
@@ -137,8 +151,7 @@ IMUInfo RealSenseD435I::getIMUInfo(const rs2::frame & frame, const stream_index_
 sensor_msgs::msg::Imu RealSenseD435I::CreateUnitedMessage(const CimuData accel_data, const CimuData gyro_data)
 {
   sensor_msgs::msg::Imu imu_msg;
-  rclcpp::Time t = msToTime(gyro_data.m_time);
-  imu_msg.header.stamp = t;
+  imu_msg.header.stamp = msToTime(gyro_data.m_time);
 
   imu_msg.angular_velocity.x = gyro_data.m_data.x();
   imu_msg.angular_velocity.y = gyro_data.m_data.y();
@@ -168,16 +181,10 @@ void RealSenseD435I::FillImuData_Copy(const CimuData imu_data, std::deque<sensor
 
 void RealSenseD435I::ImuMessage_AddDefaultValues(sensor_msgs::msg::Imu& imu_msg)
 {
-//  TODO: get type_index properly
-  auto type_index = GYRO;
-  imu_msg.header.frame_id = OPTICAL_FRAME_ID.at(type_index);
-
   imu_msg.orientation.x = 0.0;
   imu_msg.orientation.y = 0.0;
   imu_msg.orientation.z = 0.0;
   imu_msg.orientation.w = 0.0;
-
-
   imu_msg.orientation_covariance = {-1.0, 0.0, 0.0,
                                     0.0, 0.0, 0.0,
                                     0.0, 0.0, 0.0};
@@ -187,6 +194,66 @@ void RealSenseD435I::ImuMessage_AddDefaultValues(sensor_msgs::msg::Imu& imu_msg)
   imu_msg.angular_velocity_covariance = {angular_velocity_cov_, 0.0, 0.0,
                                          0.0, angular_velocity_cov_, 0.0,
                                          0.0, 0.0, angular_velocity_cov_};
+}
+
+void RealSenseD435I::imu_callback_sync(const rs2::frame & frame, imu_sync_method sync_method)
+{
+  static std::mutex m_mutex;
+
+  m_mutex.lock();
+
+  auto type = frame.get_profile().stream_type();
+  auto index = frame.get_profile().stream_index();
+  auto type_index = std::pair<rs2_stream, int>(type, index);
+
+  double frame_time = frame.get_timestamp();
+
+//  TODO: Sort out initialized_time with ros2 node clock
+//  bool placeholder_false(false);
+//  if (_is_initialized_time_base.compare_exchange_strong(placeholder_false, true) )
+//  {
+//    setBaseTime(frame_time, RS2_TIMESTAMP_DOMAIN_SYSTEM_TIME == frame.get_frame_timestamp_domain());
+//  }
+//  double elapsed_camera_ms = (/*ms*/ frame_time - /*ms*/ _camera_time_base) / 1000.0;
+  double elapsed_camera_ms = frame_time;
+
+//  if (0 != _synced_imu_publisher->getNumSubscribers())
+  if (true)
+  {
+    auto crnt_reading = *(reinterpret_cast<const float3*>(frame.get_data()));
+    Eigen::Vector3d v(crnt_reading.x, crnt_reading.y, crnt_reading.z);
+    CimuData imu_data(type_index, v, elapsed_camera_ms);
+    std::deque<sensor_msgs::msg::Imu> imu_msgs;
+    switch (sync_method)
+    {
+      case COPY:
+        FillImuData_Copy(imu_data, imu_msgs);
+        break;
+      case LINEAR_INTERPOLATION:
+        FillImuData_LinearInterpolation(imu_data, imu_msgs);
+        break;
+    }
+    while (imu_msgs.size())
+    {
+      auto imu_msg = imu_msgs.front();
+
+//      TODO: Sort out _ros_time_base with ros2 node clock
+//      ros::Time t(_ros_time_base.toSec() + imu_msg.header.stamp.toSec());
+
+//      rclcpp::Time t = frameToTime(frame);
+//      imu_msg.header.stamp = t;
+
+      imu_msg.header.frame_id = OPTICAL_FRAME_ID.at(IMU);
+      ImuMessage_AddDefaultValues(imu_msg);
+      imu_pub_[IMU]->publish(imu_msg);
+
+//      info_msg = getIMUInfo(frame, IMU);
+//      imu_info_pub_[IMU]->publish(info_msg);
+      RCLCPP_DEBUG(node_.get_logger(), "Publish united %s stream", rs2_stream_to_string(frame.get_profile().stream_type()));
+      imu_msgs.pop_front();
+    }
+  }
+  m_mutex.unlock();
 }
 
 template <typename T> T lerp(const T &a, const T &b, const double t) {

--- a/realsense_ros/src/rs_d435i.cpp
+++ b/realsense_ros/src/rs_d435i.cpp
@@ -58,6 +58,8 @@ Result RealSenseD435I::paramChangeCallback(const std::vector<rclcpp::Parameter> 
         result = toggleStream(ACCEL, param);
       } else if (param_name == "gyro0.enabled") {
         result = toggleStream(GYRO, param);
+      } else if (param_name == "imu0.enabled") {
+        result = toggleStream(IMU, param);
       }
     }
   }

--- a/realsense_ros/src/rs_d435i.cpp
+++ b/realsense_ros/src/rs_d435i.cpp
@@ -35,7 +35,7 @@ RealSenseD435I::RealSenseD435I(rs2::context ctx, rs2::device dev, rclcpp::Node &
 
 void RealSenseD435I::publishTopicsCallback(const rs2::frame & frame)
 {
-  rclcpp::Time t = node_.now();
+  rclcpp::Time t = frameToTime(frame);
   if (frame.is<rs2::frameset>()) {
     RealSenseD435::publishTopicsCallback(frame);
   } else if (frame.is<rs2::motion_frame>()) {

--- a/realsense_ros/src/rs_t265.cpp
+++ b/realsense_ros/src/rs_t265.cpp
@@ -42,7 +42,7 @@ RealSenseT265::RealSenseT265(rs2::context ctx, rs2::device dev, rclcpp::Node & n
 
 void RealSenseT265::publishTopicsCallback(const rs2::frame & frame)
 {
-  rclcpp::Time t = node_.now();
+  rclcpp::Time t = frameToTime(frame);
 
   if (frame.is<rs2::frameset>()) {
     auto frameset = frame.as<rs2::frameset>();


### PR DESCRIPTION
Fixes https://github.com/intel/ros2_intel_realsense/issues/103 by adding support for linearly interpolating Gyro and Accel and publishing it over a single IMU topic. Adapted from https://github.com/IntelRealSense/realsense-ros/pull/558 and https://github.com/IntelRealSense/realsense-ros/pull/1010 .

Extends: https://github.com/intel/ros2_intel_realsense/pull/105