### PR TITLE
Update for ROS2 Foxy release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Changelog for ros2_intel_realsense
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+2.0.7 (2020-04-20)
+------------------
+Support the latest release(v2.34.0) of librealsense
+Support ROS2 Foxy release
+
 2.0.6 (2019-09-03)
 ------------------
 * support multi camera

--- a/realsense_examples/package.xml
+++ b/realsense_examples/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>realsense_examples</name>
-  <version>2.0.5</version>
+  <version>2.0.7</version>
   <description>ROS2 RealSense Package Exampless</description>
   <maintainer email="xiaojun.huang@intel.com">Xiaojun Huang</maintainer>
   <license>Apache License 2.0</license>

--- a/realsense_msgs/package.xml
+++ b/realsense_msgs/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>realsense_msgs</name>
-  <version>2.0.5</version>
+  <version>2.0.7</version>
   <description>Message Definition for ROS2 RealSense Package</description>
   <maintainer email="xiaojun.huang@intel.com">Xiaojun Huang</maintainer>
   <license>Apache License 2.0</license>

--- a/realsense_node/package.xml
+++ b/realsense_node/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>realsense_node</name>
-  <version>2.0.5</version>
+  <version>2.0.7</version>
   <description>ROS2 realsense node</description>
   <maintainer email="xiaojun.huang@intel.com">Xiaojun Huang</maintainer>
   <license>Apache License 2.0</license>

--- a/realsense_ros/package.xml
+++ b/realsense_ros/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>realsense_ros</name>
-  <version>2.0.5</version>
+  <version>2.0.7</version>
   <description>ROS2 RealSense Package</description>
   <maintainer email="xiaojun.huang@intel.com">Xiaojun Huang</maintainer>
   <license>Apache License 2.0</license>


### PR DESCRIPTION
Bump version number 2.0.7
Correct the name of dependent "librealsense2".