### PR TITLE
ros2 realsense: removed dependent on cv_bridge.

### DIFF
--- a/realsense_node/CMakeLists.txt
+++ b/realsense_node/CMakeLists.txt
@@ -68,11 +68,19 @@ find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(nav_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
-find_package(cv_bridge REQUIRED)
+find_package(OpenCV REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(realsense_ros REQUIRED)
 find_package(realsense_msgs REQUIRED)
+
+find_library(realsense2_LIBRARIES realsense2)
+find_path(realsense2_INCLUDE_DIRS librealsense2/rs.hpp)
+
+include_directories(
+  ${CMAKE_CURRENT_SOURCE_DIR}/include
+  ${realsense2_INCLUDE_DIRS}
+)
 
 add_executable(realsense_node
   src/realsense_node.cpp
@@ -82,11 +90,14 @@ ament_target_dependencies(realsense_node
   rclcpp
   nav_msgs
   sensor_msgs
-  cv_bridge
   tf2
   tf2_ros
   realsense_ros
   realsense_msgs
+)
+
+target_link_libraries(realsense_node
+  ${OpenCV_LIBRARIES}
 )
 
 install(TARGETS realsense_node

--- a/realsense_node/package.xml
+++ b/realsense_node/package.xml
@@ -12,7 +12,6 @@
   <depend>rclcpp</depend>
   <depend>nav_msgs</depend>
   <depend>sensor_msgs</depend>
-  <depend>cv_bridge</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
   <depend>realsense_ros</depend>

--- a/realsense_ros/CMakeLists.txt
+++ b/realsense_ros/CMakeLists.txt
@@ -69,16 +69,17 @@ find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(nav_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
-find_package(cv_bridge REQUIRED)
+find_package(OpenCV REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_ros REQUIRED)
-find_package(pcl_conversions REQUIRED)
 find_package(realsense_msgs)
 
 find_package(realsense2)
 if(NOT realsense2_FOUND)
   message(FATAL_ERROR "\n\n Intel RealSense SDK 2.0 is missing, please install it from https://github.com/IntelRealSense/librealsense/releases\n\n")
 endif()
+find_library(realsense2_LIBRARIES realsense2)
+find_path(realsense2_INCLUDE_DIRS librealsense2/rs.hpp)
 
 include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}/include
@@ -96,7 +97,8 @@ add_library(${PROJECT_NAME} SHARED
 )
 
 target_link_libraries(${PROJECT_NAME}
-  realsense2
+  ${realsense2_LIBRARIES}
+  ${OpenCV_LIBRARIES}
 )
 
 ament_target_dependencies(${PROJECT_NAME}
@@ -104,10 +106,8 @@ ament_target_dependencies(${PROJECT_NAME}
   rclcpp_components
   nav_msgs
   sensor_msgs
-  cv_bridge
   tf2
   tf2_ros
-  pcl_conversions
   realsense2
   realsense_msgs
 )
@@ -136,10 +136,8 @@ if(BUILD_TESTING)
   find_package(rclcpp REQUIRED)
   find_package(nav_msgs REQUIRED)
   find_package(sensor_msgs REQUIRED)
-  find_package(cv_bridge REQUIRED)
   find_package(tf2 REQUIRED)
   find_package(tf2_ros REQUIRED)
-  find_package(pcl_conversions REQUIRED)
   find_package(realsense_msgs)
   find_package(realsense2)
   find_package(image_transport REQUIRED)
@@ -159,16 +157,14 @@ if(BUILD_TESTING)
         ${${PROJECT_NAME}_INCLUDE_DIRS}
       )
       target_link_libraries(${target}
-        realsense2
+        ${realsense2_LIBRARIES}
 	${PROJECT_NAME})
       ament_target_dependencies(${target}
         "rclcpp"
         "nav_msgs"
         "sensor_msgs"
-        "cv_bridge"
         "tf2"
 	"tf2_ros"
-        "pcl_conversions"
         "realsense_msgs"
         "realsense2"
         "image_transport")

--- a/realsense_ros/include/realsense/rs_base.hpp
+++ b/realsense_ros/include/realsense/rs_base.hpp
@@ -19,6 +19,7 @@
 #include "sensor_msgs/msg/image.hpp"
 #include "sensor_msgs/msg/camera_info.hpp"
 #include "sensor_msgs/msg/imu.hpp"
+#include "std_msgs/msg/header.hpp"
 #include "nav_msgs/msg/odometry.hpp"
 #include "tf2/LinearMath/Quaternion.h"
 #include "tf2_ros/static_transform_broadcaster.h"
@@ -80,6 +81,10 @@ protected:
   Result toggleStream(const stream_index_pair & stream, const rclcpp::Parameter & param);
   Result changeResolution(const stream_index_pair & stream, const rclcpp::Parameter & param);
   Result changeFPS(const stream_index_pair & stream, const rclcpp::Parameter & param);
+  void toMsg(const std_msgs::msg::Header& header,
+    const std::string& encoding, const cv::Mat& image, sensor_msgs::msg::Image & ros_image);
+  sensor_msgs::msg::Image::SharedPtr toMsg(const std_msgs::msg::Header& header,
+    const std::string& encoding, const cv::Mat& image = cv::Mat());
 
   typedef struct VideoStreamInfo
   {

--- a/realsense_ros/include/realsense/rs_constants.hpp
+++ b/realsense_ros/include/realsense/rs_constants.hpp
@@ -14,8 +14,8 @@
 
 #ifndef REALSENSE__RS_CONSTANTS_HPP_
 #define REALSENSE__RS_CONSTANTS_HPP_
-
-#include "cv_bridge/cv_bridge.h"
+#include <sensor_msgs/image_encodings.hpp>
+#include <opencv2/imgproc/types_c.h>
 
 namespace realsense
 {

--- a/realsense_ros/include/realsense/rs_d435.hpp
+++ b/realsense_ros/include/realsense/rs_d435.hpp
@@ -15,7 +15,6 @@
 #ifndef REALSENSE__RS_D435_HPP_
 #define REALSENSE__RS_D435_HPP_
 
-#include "cv_bridge/cv_bridge.h"
 #include "sensor_msgs/msg/camera_info.hpp"
 #include "sensor_msgs/msg/image.hpp"
 #include "sensor_msgs/msg/point_cloud2.hpp"

--- a/realsense_ros/package.xml
+++ b/realsense_ros/package.xml
@@ -13,10 +13,8 @@
   <depend>rclcpp_components</depend>
   <depend>nav_msgs</depend>
   <depend>sensor_msgs</depend>
-  <depend>cv_bridge</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
-  <depend>pcl_conversions</depend>
   <depend>librealsense2</depend>
   <depend>realsense_msgs</depend>
   <depend>image_transport</depend>

--- a/realsense_ros/src/rs_d435.cpp
+++ b/realsense_ros/src/rs_d435.cpp
@@ -170,7 +170,7 @@ void RealSenseD435::publishAlignedDepthTopic(const rs2::frame & frame, const rcl
 
   if (!node_.get_node_options().use_intra_process_comms()) {
     sensor_msgs::msg::Image::SharedPtr img;
-    img = cv_bridge::CvImage(std_msgs::msg::Header(), MSG_ENCODING.at(type), cv_image).toImageMsg();
+    img = toMsg(std_msgs::msg::Header(), MSG_ENCODING.at(type), cv_image);
     //debug
     //RCLCPP_INFO(node_->get_logger(), "timestamp: %f, address: %p", t.seconds(), reinterpret_cast<std::uintptr_t>(img.get()));
     //
@@ -180,7 +180,7 @@ void RealSenseD435::publishAlignedDepthTopic(const rs2::frame & frame, const rcl
   } else {
     sensor_msgs::msg::Image::UniquePtr img;
     img = std::make_unique<sensor_msgs::msg::Image>();
-    cv_bridge::CvImage(std_msgs::msg::Header(), sensor_msgs::image_encodings::RGB8, cv_image).toImageMsg(*img);
+    toMsg(std_msgs::msg::Header(), sensor_msgs::image_encodings::RGB8, cv_image, *img);
     //debug
     //RCLCPP_INFO(node_->get_logger(), "timestamp: %f, address: %p", t.seconds(), reinterpret_cast<std::uintptr_t>(img.get()));
     //

--- a/realsense_ros/tests/camera_core.hpp
+++ b/realsense_ros/tests/camera_core.hpp
@@ -38,7 +38,6 @@
 #include "sensor_msgs/point_cloud2_iterator.hpp"
 #include "realsense/rs_constants.hpp"
 #include "realsense/rs_base.hpp"
-#include "cv_bridge/cv_bridge.h"
 
 #include "image_transport/image_transport.h"
 #include "image_transport/camera_subscriber.h"


### PR DESCRIPTION
The dependence to cv_bridge is minor, only for message conversion.
Less coupling helps being more independent for ROS2 release.

Signed-off-by: Sharron LIU <sharron.xr.liu@gmail.com>