### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/realsense_ros/CMakeLists.txt
+++ b/realsense_ros/CMakeLists.txt
@@ -97,7 +97,7 @@ add_library(${PROJECT_NAME} SHARED
 )
 
 target_link_libraries(${PROJECT_NAME}
-  ${realsense2_LIBRARIES}
+  realsense2::realsense2
   ${OpenCV_LIBRARIES}
 )
 


### PR DESCRIPTION
This fixes a build error when the realsense2 library is built as a static library instead of the default shared library

```
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `rosbag::View::getConnections()'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `rosbag::View::iterator::~iterator()'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `libusb_get_device_descriptor'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `libusb_control_transfer'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `rs2rosinternal::TimeBase<rs2rosinternal::Time, rs2rosinternal::Duration>::operator>(rs2rosinternal::Time const&) const'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `libusb_free_config_descriptor'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `rosbag::Bag::Bag()'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `libusb_get_bus_number'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `rosbag::View::begin()'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `rs2rosinternal::TimeBase<rs2rosinternal::Time, rs2rosinternal::Duration>::operator-(rs2rosinternal::Time const&) const'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `rosbag::View::iterator::increment()'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `libusb_close'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `rosbag::Bag::stopWritingChunk()'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `rosbag::Bag::startWritingChunk(rs2rosinternal::Time)'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `libusb_submit_transfer'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `libusb_get_device_address'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `rosbag::TopicQuery::TopicQuery(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&)'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `rosbag::Bag::toHeaderString[abi:cxx11](rs2rosinternal::Time const*) const'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `rosbag::View::View(rosbag::Bag const&, boost::function<bool (rosbag::ConnectionInfo const*)>, rs2rosinternal::Time const&, rs2rosinternal::Time const&, bool const&)'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `libusb_init'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `rs2rosinternal::TimeBase<rs2rosinternal::Time, rs2rosinternal::Duration>::operator==(rs2rosinternal::Time const&) const'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `libusb_get_port_numbers'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `rs2rosinternal::Header::~Header()'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `rs2rosinternal::TimeBase<rs2rosinternal::Time, rs2rosinternal::Duration>::operator+(rs2rosinternal::Duration const&) const'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `rosbag::Bag::appendDataLengthToBuffer(rosbag::Buffer&, unsigned int)'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `rs2rosinternal::DurationBase<rs2rosinternal::Duration>::DurationBase(int, int)'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `rosbag::Bag::readMessageDataRecord102(unsigned long long, rs2rosinternal::Header&) const'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `libusb_clear_halt'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `libusb_detach_kernel_driver'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `rosbag::View::getBeginTime()'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `rosbag::View::~View()'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `rosbag::Bag::~Bag()'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `libusb_unref_device'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `libusb_handle_events_completed'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `rs2rosinternal::serialization::throwStreamOverrun()'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `rosbag::MessageInstance::getTime() const'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `fw_target_size'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `libusb_kernel_driver_active'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `rosbag::View::getEndTime()'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `rosbag::Bag::write(char const*, int)'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `rosbag::Bag::decompressChunk(unsigned long long) const'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `rosbag::Bag::readField(std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&) const'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `rosbag::Buffer::setSize(unsigned int)'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `rosbag::View::size()'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `rosbag::Bag::getChunkOffset() const'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `libusb_bulk_transfer'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `rosbag::Bag::writeHeader(std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > const&)'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `libusb_free_device_list'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `libusb_claim_interface'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `rosbag::Bag::readMessageDataHeaderFromBuffer(rosbag::Buffer&, unsigned int, rs2rosinternal::Header&, unsigned int&, unsigned int&) const'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `libusb_get_config_descriptor'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `libusb_interrupt_transfer'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `rosbag::ChunkedFile::getOffset() const'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `rosbag::View::iterator::equal(rosbag::View::iterator const&) const'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `rosbag::Bag::appendConnectionRecordToBuffer(rosbag::Buffer&, rosbag::ConnectionInfo const*)'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `rosbag::Bag::setCompression(rosbag::compression::CompressionType)'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `rs2rosinternal::TIME_MIN'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `rosbag::MessageInstance::getTopic[abi:cxx11]() const'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `libusb_free_transfer'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `rs2rosinternal::TimeBase<rs2rosinternal::Time, rs2rosinternal::Duration>::operator<(rs2rosinternal::Time const&) const'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `rosbag::Buffer::getSize() const'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `rosbag::View::iterator::operator=(rosbag::View::iterator const&)'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `rosbag::View::iterator::dereference() const'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `rosbag::TopicQuery::operator()(rosbag::ConnectionInfo const*) const'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `rosbag::Bag::writeConnectionRecord(rosbag::ConnectionInfo const*)'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `rosbag::MessageInstance::getMD5Sum[abi:cxx11]() const'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `rs2rosinternal::TIME_MAX'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `rosbag::Bag::seek(unsigned long long, int) const'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `libusb_open'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `rosbag::View::iterator::iterator(rosbag::View::iterator const&)'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `libusb_cancel_transfer'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `libusb_get_device_list'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `libusb_exit'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `rosbag::Bag::writeDataLength(unsigned int)'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `libusb_release_interface'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `rosbag::View::addQuery(rosbag::Bag const&, boost::function<bool (rosbag::ConnectionInfo const*)>, rs2rosinternal::Time const&, rs2rosinternal::Time const&)'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `rosbag::Bag::appendHeaderToBuffer(rosbag::Buffer&, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > const&)'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `rosbag::TopicQuery::TopicQuery(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `rosbag::Bag::close()'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `rosbag::Buffer::getData()'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `rosbag::MessageInstance::getDataType[abi:cxx11]() const'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `rosbag::View::iterator::iterator()'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `libusb_ref_device'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `rosbag::Bag::open(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, unsigned int)'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `rosbag::View::end()'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `rs2rosinternal::Header::Header()'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `libusb_alloc_transfer'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `rosbag::Bag::checkField(std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, unsigned int, unsigned int, bool) const'
/usr/lib/gcc-cross/arm-linux-gnueabihf/8/../../../../arm-linux-gnueabihf/bin/ld: /root/ws/install/lib/librealsense_ros.so: undefined reference to `fw_target_data'
collect2: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/realsense_node.dir/build.make:221: realsense_node] Error 1
make[1]: *** [CMakeFiles/Makefile2:140: CMakeFiles/realsense_node.dir/all] Error 2
make: *** [Makefile:144: all] Error 2
```