### PR TITLE
Add missing dependency on libopencv-dev in package.xml

### DIFF
--- a/realsense_node/package.xml
+++ b/realsense_node/package.xml
@@ -9,6 +9,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>libopencv-dev</depend>
   <depend>rclcpp</depend>
   <depend>nav_msgs</depend>
   <depend>sensor_msgs</depend>

--- a/realsense_ros/package.xml
+++ b/realsense_ros/package.xml
@@ -9,6 +9,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>libopencv-dev</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>nav_msgs</depend>


### PR DESCRIPTION
I think this should help resolve the ROS buildfarm failures we see for Foxy:

http://build.ros2.org/job/Fbin_uF64__realsense_ros__ubuntu_focal_amd64__binary/75